### PR TITLE
Add an option to configure the maximum limit

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -46,11 +46,15 @@ defmodule Paginator do
     * `:include_total_count` - Set this to true to return the total number of
     records matching the query. Note that this number will be capped by
     `:total_count_limit`. Defaults to `false`.
-    * `:limit` - Limits the number of records returned per page. Defaults to 50.
+    * `:limit` - Limits the number of records returned per page. Note that this
+    number will be capped by `:maximum_limit`. Defaults to `50`.
+    * `:maximum_limit` - Sets a maximum cap for `:limit`. This option can be useful when `:limit`
+    is set dynamically (e.g from a URL param set by a user) but you still want to
+    enfore a maximum. Defaults to `500`.
     * `:sort_direction` - The direction used for sorting. Defaults to `:asc`.
     * `:total_count_limit` - Running count queries on tables with a large number
     of records is expensive so it is capped by default. Can be set to `:infinity`
-    in order to count all the records. Defaults to 10,000.
+    in order to count all the records. Defaults to `10,000`.
 
   ## Repo options
 

--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -13,15 +13,17 @@ defmodule Paginator.Config do
     :cursor_fields,
     :include_total_count,
     :limit,
+    :maximum_limit,
     :sort_direction,
     :total_count_limit
   ]
 
   @default_limit 50
   @minimum_limit 1
+  @maximum_limit 500
   @default_total_count_limit 10_000
 
-  def new(opts) do
+  def new(opts \\ []) do
     %__MODULE__{
       after: opts[:after],
       after_values: Cursor.decode(opts[:after]),
@@ -29,9 +31,14 @@ defmodule Paginator.Config do
       before_values: Cursor.decode(opts[:before]),
       cursor_fields: opts[:cursor_fields],
       include_total_count: opts[:include_total_count] || false,
-      limit: max(opts[:limit] || @default_limit, @minimum_limit),
+      limit: limit(opts),
       sort_direction: opts[:sort_direction] || :asc,
       total_count_limit: opts[:total_count_limit] || @default_total_count_limit
     }
+  end
+
+  defp limit(opts) do
+    max(opts[:limit] || @default_limit, @minimum_limit)
+    |> min(opts[:maximum_limit] || @maximum_limit)
   end
 end

--- a/test/paginator/config_test.exs
+++ b/test/paginator/config_test.exs
@@ -14,6 +14,31 @@ defmodule Paginator.ConfigTest do
     end
   end
 
+  describe "Config.new/2 applies min/max limit" do
+    test "applies default limit" do
+      config = Config.new()
+      assert config.limit == 50
+    end
+
+    test "applies minimum limit" do
+      config = Config.new(limit: 0)
+      assert config.limit == 1
+    end
+
+    test "applies maximum limit" do
+      config = Config.new(limit: 1000)
+      assert config.limit == 500
+    end
+
+    test "respects configured maximum limit" do
+      config = Config.new(limit: 1000, maximum_limit: 2000)
+      assert config.limit == 1000
+
+      config = Config.new(limit: 3000, maximum_limit: 2000)
+      assert config.limit == 2000
+    end
+  end
+
   describe "Config.new/2 decodes cusors" do
     test "simple before" do
       config = Config.new(limit: 10, cursor_fields: [:id], before: simple_before())


### PR DESCRIPTION
This can be useful when `limit` is set dynamically by the users.