### PR TITLE
potential denial of service vector

### DIFF
--- a/lib/paginator/cursor.ex
+++ b/lib/paginator/cursor.ex
@@ -6,7 +6,7 @@ defmodule Paginator.Cursor do
   def decode(encoded_cursor) do
     encoded_cursor
     |> Base.url_decode64!()
-    |> :erlang.binary_to_term()
+    |> :erlang.binary_to_term([:safe])
   end
 
   def encode(values) when is_list(values) do

--- a/test/paginator/cursor_test.exs
+++ b/test/paginator/cursor_test.exs
@@ -1,0 +1,31 @@
+defmodule Paginator.CursorTest do
+  use ExUnit.Case, async: true
+
+  alias Paginator.Cursor
+
+  describe "encoding and decoding terms" do
+    test "it wraps terms into lists" do
+      cursor = Cursor.encode(1)
+
+      assert Cursor.decode(cursor) == [1]
+    end
+
+    test "it doesn't wrap a list in a list" do
+      cursor = Cursor.encode([1])
+
+      assert Cursor.decode(cursor) == [1]
+      refute Cursor.decode(cursor) == [[1]]
+    end
+  end
+
+  describe "Cursor.decode/1" do
+    test "it safely decodes user input" do
+      assert_raise ArgumentError, fn ->
+        # this binary represents the atom :fubar_0a1b2c3d4e
+        <<131, 100, 0, 16, "fubar_0a1b2c3d4e">>
+        |> Base.url_encode64()
+        |> Cursor.decode()
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've been testing this locally and have been able to bring down my local node by sending requests with cursors that decode into non-existent atoms.

Because these cursors are user-supplied, the library should switch to using `:erlang.binary_to_term/2` with the `[:safe]` option during the decoding step.