### PR TITLE
Fix comparison with nil arising when sorting by fields other than id

### DIFF
--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -18,7 +18,10 @@ defmodule Paginator.Ecto.Query do
   end
 
   defp filter_values(query, cursor_fields, values, operator) do
-    sorts = Enum.zip(cursor_fields, values)
+    sorts =
+      cursor_fields
+      |> Enum.zip(values)
+      |> Enum.reject(fn val -> match?({_column, nil}, val) end)
 
     dynamic_sorts =
       sorts

--- a/test/paginator_test.exs
+++ b/test/paginator_test.exs
@@ -515,6 +515,26 @@ defmodule PaginatorTest do
       assert to_ids(entries) == to_ids([])
       assert metadata == %Metadata{after: nil, before: nil, limit: 8}
     end
+
+    test "sorts with respect to nil values", %{
+      payments: {_p1, _p2, _p3, _p4, _p5, _p6, p7, _p8, _p9, _p10, p11, _p12} = payments
+    } do
+      %Page{entries: entries, metadata: metadata} =
+        payments_by_charged_at(:desc)
+        |> Repo.paginate(
+          cursor_fields: [:charged_at, :id],
+          sort_direction: :desc,
+          after: encode_cursor([nil, nil]),
+          limit: 8
+        )
+
+        assert Enum.count(entries) == 8
+        assert metadata == %Metadata{
+          before: encode_cursor([p11.charged_at, p11.id]),
+          limit: 8,
+          after: encode_cursor([p7.charged_at, p7.id])
+        }
+    end
   end
 
   test "applies a default limit if none is provided", %{


### PR DESCRIPTION
If using multiple `cursor_fields` (e.g. `[:charged_at, :id]`) in certain situations query builder will fail with following error:

```
** (ArgumentError) comparison with nil is forbidden as it is unsafe. If you want to check if a value is nil, use is_nil/1 instead
code: |> Repo.paginate(
stacktrace:
       (ecto) lib/ecto/query/builder.ex:551: Ecto.Query.Builder.not_nil!/1
       (paginator) lib/paginator/ecto/query.ex:42: anonymous fn/4 in Paginator.Ecto.Query.filter_values/4
       (ecto) lib/ecto/query/builder/dynamic.ex:50: Ecto.Query.Builder.Dynamic.expand/3
       (elixir) lib/enum.ex:1397: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir) lib/macro.ex:243: Macro.do_traverse/4
       (ecto) lib/ecto/query/builder/dynamic.ex:32: Ecto.Query.Builder.Dynamic.fully_expand/2
       (ecto) lib/ecto/query/builder/filter.ex:94: Ecto.Query.Builder.Filter.filter!/6
       (ecto) lib/ecto/query/builder/filter.ex:115: Ecto.Query.Builder.Filter.filter!/7
       (paginator) lib/paginator/ecto/query.ex:12: Paginator.Ecto.Query.paginate/2
       (paginator) lib/paginator.ex:174: Paginator.entries/4
       (paginator) lib/paginator.ex:93: Paginator.paginate/4
       test/paginator_test.exs:522: (test)
```

Added test case and fixed bug by filtering out 'nil' values before building query in `Paginator.Ecto.Query.filter_values/4`.