### PR TITLE
Add ability to have diferent sorting directions per field

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -171,7 +171,7 @@ defmodule Paginator do
 
   defp fetch_cursor_value(schema, %Config{cursor_fields: cursor_fields}) do
     cursor_fields
-    |> Enum.map(fn field -> Map.get(schema, field) end)
+    |> Enum.map(fn {field, _} -> Map.get(schema, field) end)
     |> Cursor.encode()
   end
 

--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -31,17 +31,40 @@ defmodule Paginator.Config do
       after_values: Cursor.decode(opts[:after]),
       before: opts[:before],
       before_values: Cursor.decode(opts[:before]),
-      cursor_fields: opts[:cursor_fields],
+      cursor_fields: opts[:cursor_fields] || [],
       include_total_count: opts[:include_total_count] || false,
-      total_count_primary_key_field: opts[:total_count_primary_key_field] || @default_total_count_primary_key_field,
+      total_count_primary_key_field:
+        opts[:total_count_primary_key_field] || @default_total_count_primary_key_field,
       limit: limit(opts),
-      sort_direction: opts[:sort_direction] || :asc,
+      sort_direction: opts[:sort_direction],
       total_count_limit: opts[:total_count_limit] || @default_total_count_limit
     }
+    |> convert_deprecated_config()
   end
 
   defp limit(opts) do
     max(opts[:limit] || @default_limit, @minimum_limit)
     |> min(opts[:maximum_limit] || @maximum_limit)
+  end
+
+  defp convert_deprecated_config(config) do
+    case {config, Keyword.keyword?(config.cursor_fields)} do
+      {%__MODULE__{sort_direction: _}, true} ->
+        config
+
+      {%__MODULE__{sort_direction: nil}, false} ->
+        %{config | cursor_fields: make_keyword_list(config.cursor_fields, :asc)}
+
+      {%__MODULE__{sort_direction: direction}, false} ->
+        %{
+          config
+          | cursor_fields: make_keyword_list(config.cursor_fields, direction),
+            sort_direction: nil
+        }
+    end
+  end
+
+  defp make_keyword_list(fields, sorting_direction) do
+    Enum.map(fields, fn x -> {x, sorting_direction} end)
   end
 end

--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -53,18 +53,22 @@ defmodule Paginator.Config do
         config
 
       {%__MODULE__{sort_direction: nil}, false} ->
-        %{config | cursor_fields: make_keyword_list(config.cursor_fields, :asc)}
+        %{
+          config
+          | cursor_fields: build_cursor_fields_from_sort_direction(config.cursor_fields, :asc)
+        }
 
       {%__MODULE__{sort_direction: direction}, false} ->
         %{
           config
-          | cursor_fields: make_keyword_list(config.cursor_fields, direction),
+          | cursor_fields:
+              build_cursor_fields_from_sort_direction(config.cursor_fields, direction),
             sort_direction: nil
         }
     end
   end
 
-  defp make_keyword_list(fields, sorting_direction) do
+  defp build_cursor_fields_from_sort_direction(fields, sorting_direction) do
     Enum.map(fields, fn x -> {x, sorting_direction} end)
   end
 end

--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -17,7 +17,17 @@ defmodule Paginator.Ecto.Query do
     paginate(queryable, Config.new(opts))
   end
 
-  defp filter_values(query, cursor_fields, values, operator) do
+  defp filter_values(query, cursor_fields, values, :lt) do
+    operator_list = Enum.map(cursor_fields, fn x -> {x, :lt} end)
+    filter_values(query, cursor_fields, values, operator_list)
+  end
+
+  defp filter_values(query, cursor_fields, values, :gt) do
+    operator_list = Enum.map(cursor_fields, fn x -> {x, :gt} end)
+    filter_values(query, cursor_fields, values, operator_list)
+  end
+
+  defp filter_values(query, cursor_fields, values, operators) when is_list(operators) do
     sorts =
       cursor_fields
       |> Enum.zip(values)
@@ -30,7 +40,7 @@ defmodule Paginator.Ecto.Query do
         dynamic = true
 
         dynamic =
-          case operator do
+          case Keyword.get(operators, column) do
             :lt ->
               dynamic([q], field(q, ^column) < ^value and ^dynamic)
 
@@ -133,6 +143,112 @@ defmodule Paginator.Ecto.Query do
     query
     |> filter_values(cursor_fields, after_values, :lt)
     |> filter_values(cursor_fields, before_values, :gt)
+  end
+
+  defp maybe_where(query, %Config{
+         after: nil,
+         before: nil,
+         cursor_fields: cursor_fields,
+         sort_direction: sort_direction
+       })
+       when is_list(sort_direction) do
+    validate_sort_direction_list!(sort_direction, cursor_fields)
+
+    query
+  end
+
+  defp maybe_where(query, %Config{
+         after_values: after_values,
+         before: nil,
+         cursor_fields: cursor_fields,
+         sort_direction: sort_direction
+       })
+       when is_list(sort_direction) do
+    validate_sort_direction_list!(sort_direction, cursor_fields)
+
+    query
+    |> filter_values(
+      cursor_fields,
+      after_values,
+      convert_sort_direction_list(sort_direction, :before)
+    )
+  end
+
+  defp maybe_where(query, %Config{
+         after: nil,
+         before_values: before_values,
+         cursor_fields: cursor_fields,
+         sort_direction: sort_direction
+       })
+       when is_list(sort_direction) do
+    validate_sort_direction_list!(sort_direction, cursor_fields)
+
+    query
+    |> filter_values(
+      cursor_fields,
+      before_values,
+      convert_sort_direction_list(sort_direction, :before)
+    )
+    |> reverse_order_bys()
+  end
+
+  defp maybe_where(query, %Config{
+         after_values: after_values,
+         before_values: before_values,
+         cursor_fields: cursor_fields,
+         sort_direction: sort_direction
+       })
+       when is_list(sort_direction) do
+    validate_sort_direction_list!(sort_direction, cursor_fields)
+
+    query
+    |> filter_values(
+      cursor_fields,
+      after_values,
+      convert_sort_direction_list(sort_direction, :after)
+    )
+    |> filter_values(
+      cursor_fields,
+      before_values,
+      convert_sort_direction_list(sort_direction, :before)
+    )
+  end
+
+  # performs checks on the provided config before we run queries
+  defp validate_sort_direction_list!(direction, cursor_fields) do
+    # the list must be a keyword list
+    unless Keyword.keyword?(direction),
+      do: raise("Expected sort direction to either be a keyword list, :asc or :desc")
+
+    # Check whether all cursor fields have a sorting direction associated
+    missing_fields = Enum.filter(cursor_fields, fn x -> !Keyword.has_key?(direction, x) end)
+
+    # if there are fields missing a direction, raise an error informing about the missing fields
+    if length(missing_fields) > 0 do
+      missing_fields = Enum.join(missing_fields, ", ")
+      raise("There is no sorting direction provided for the fields #{missing_fields}")
+    end
+
+    # lastly, check whether the values are either ascending or descending
+    Enum.each(direction, fn {key, value} ->
+      if value != :desc or value != :asc,
+        do: raise("Value for #{key} is invalid, please use either :desc or :asc")
+    end)
+  end
+
+  # converts a column direction to a conditional, for example {column: :desc} to {column: :lt}
+  defp convert_sort_direction_list(direction_list, cursor_type) do
+    Enum.map(direction_list, fn {key, direction} ->
+      operator =
+        case {cursor_type, direction} do
+          {:after, :asc} -> :lt
+          {:after, :desc} -> :gt
+          {:before, :asc} -> :gt
+          {:before, :desc} -> :lt
+        end
+
+      {key, operator}
+    end)
   end
 
   #  In order to return the correct pagination cursors, we need to fetch one more

--- a/test/paginator/config_test.exs
+++ b/test/paginator/config_test.exs
@@ -10,7 +10,7 @@ defmodule Paginator.ConfigTest do
       assert config.after_values == nil
       assert config.before_values == nil
       assert config.limit == 10
-      assert config.cursor_fields == [:id]
+      assert config.cursor_fields == [id: :asc]
     end
   end
 
@@ -47,7 +47,7 @@ defmodule Paginator.ConfigTest do
       assert config.after_values == nil
       assert config.before_values == ["pay_789"]
       assert config.limit == 10
-      assert config.cursor_fields == [:id]
+      assert config.cursor_fields == [id: :asc]
     end
 
     test "simple after" do
@@ -56,7 +56,7 @@ defmodule Paginator.ConfigTest do
       assert config.after_values == ["pay_123"]
       assert config.before_values == nil
       assert config.limit == 10
-      assert config.cursor_fields == [:id]
+      assert config.cursor_fields == [id: :asc]
     end
 
     test "complex before" do
@@ -65,7 +65,7 @@ defmodule Paginator.ConfigTest do
       assert config.after_values == nil
       assert config.before_values == ["2036-02-09T20:00:00.000Z", "pay_789"]
       assert config.limit == 10
-      assert config.cursor_fields == [:created_at, :id]
+      assert config.cursor_fields == [created_at: :asc, id: :asc]
     end
 
     test "complex after" do
@@ -74,7 +74,7 @@ defmodule Paginator.ConfigTest do
       assert config.after_values == ["2036-02-09T20:00:00.000Z", "pay_123"]
       assert config.before_values == nil
       assert config.limit == 10
-      assert config.cursor_fields == [:created_at, :id]
+      assert config.cursor_fields == [created_at: :asc, id: :asc]
     end
   end
 

--- a/test/paginator_test.exs
+++ b/test/paginator_test.exs
@@ -187,7 +187,7 @@ defmodule PaginatorTest do
     end
 
     test "sorts descending with before and after cursor", %{
-      payments: {_p1, p2, p3, _p4, _p5, _p6, _p7, p8, p9, p10, _p11, p12} = p
+      payments: {_p1, p2, p3, _p4, _p5, _p6, _p7, p8, p9, p10, _p11, p12}
     } do
       %Page{entries: entries, metadata: metadata} =
         payments_by_charged_at(:desc)
@@ -517,7 +517,7 @@ defmodule PaginatorTest do
     end
 
     test "sorts with respect to nil values", %{
-      payments: {_p1, _p2, _p3, _p4, _p5, _p6, p7, _p8, _p9, _p10, p11, _p12} = payments
+      payments: {_p1, _p2, _p3, _p4, _p5, _p6, p7, _p8, _p9, _p10, p11, _p12}
     } do
       %Page{entries: entries, metadata: metadata} =
         payments_by_charged_at(:desc)

--- a/test/paginator_test.exs
+++ b/test/paginator_test.exs
@@ -719,18 +719,6 @@ defmodule PaginatorTest do
            }
   end
 
-  test "expect to raise on incorrect sorting value" do
-    assert_raise RuntimeError,
-                 "Value for field :amount in cursor_fields is invalid, please use either :desc or :asc",
-                 fn ->
-                   payments_by_amount_and_charged_at(:desc, :asc)
-                   |> Repo.paginate(
-                     cursor_fields: [amount: :test, charged_at: :asc, id: :asc],
-                     limit: 8
-                   )
-                 end
-  end
-
   defp to_ids(entries), do: Enum.map(entries, & &1.id)
 
   defp create_customers_and_payments(_context) do

--- a/test/paginator_test.exs
+++ b/test/paginator_test.exs
@@ -187,7 +187,7 @@ defmodule PaginatorTest do
     end
 
     test "sorts descending with before and after cursor", %{
-      payments: {_p1, p2, p3, _p4, _p5, _p6, _p7, p8, p9, p10, _p11, p12}
+      payments: {_p1, p2, p3, _p4, _p5, _p6, _p7, p8, p9, p10, _p11, p12} = p
     } do
       %Page{entries: entries, metadata: metadata} =
         payments_by_charged_at(:desc)
@@ -528,12 +528,13 @@ defmodule PaginatorTest do
           limit: 8
         )
 
-        assert Enum.count(entries) == 8
-        assert metadata == %Metadata{
-          before: encode_cursor([p11.charged_at, p11.id]),
-          limit: 8,
-          after: encode_cursor([p7.charged_at, p7.id])
-        }
+      assert Enum.count(entries) == 8
+
+      assert metadata == %Metadata{
+               before: encode_cursor([p11.charged_at, p11.id]),
+               limit: 8,
+               after: encode_cursor([p7.charged_at, p7.id])
+             }
     end
   end
 
@@ -651,11 +652,83 @@ defmodule PaginatorTest do
   test "per-record cursor generation", %{
     payments: {p1, _p2, _p3, _p4, _p5, _p6, p7, _p8, _p9, _p10, _p11, _p12}
   } do
-    assert Paginator.cursor_for_record(p1, [:charged_at, :id])
-    == encode_cursor([p1.charged_at, p1.id])
+    assert Paginator.cursor_for_record(p1, charged_at: :asc, id: :asc) ==
+             encode_cursor([p1.charged_at, p1.id])
 
-    assert Paginator.cursor_for_record(p7, [:amount])
-    == encode_cursor([p7.amount])
+    assert Paginator.cursor_for_record(p7, amount: :asc) == encode_cursor([p7.amount])
+  end
+
+  test "sorts on two different directions with before cursor", %{
+    payments: {_p1, _p2, _p3, p4, p5, p6, p7, _p8, _p9, _p10, _p11, _p12}
+  } do
+    %Page{entries: entries, metadata: metadata} =
+      payments_by_amount_and_charged_at(:asc, :desc)
+      |> Repo.paginate(
+        cursor_fields: [amount: :asc, charged_at: :desc, id: :asc],
+        before: encode_cursor([p7.amount, p7.charged_at, p7.id]),
+        limit: 3
+      )
+
+    assert to_ids(entries) == to_ids([p6, p4, p5])
+
+    assert metadata == %Metadata{
+             after: encode_cursor([p5.amount, p5.charged_at, p5.id]),
+             before: nil,
+             limit: 3
+           }
+  end
+
+  test "sorts on two different directions with after cursor", %{
+    payments: {_p1, _p2, _p3, p4, p5, _p6, p7, p8, _p9, _p10, _p11, _p12}
+  } do
+    %Page{entries: entries, metadata: metadata} =
+      payments_by_amount_and_charged_at(:asc, :desc)
+      |> Repo.paginate(
+        cursor_fields: [amount: :asc, charged_at: :desc, id: :asc],
+        after: encode_cursor([p4.amount, p4.charged_at, p4.id]),
+        limit: 3
+      )
+
+    assert to_ids(entries) == to_ids([p5, p7, p8])
+
+    assert metadata == %Metadata{
+             after: encode_cursor([p8.amount, p8.charged_at, p8.id]),
+             before: encode_cursor([p5.amount, p5.charged_at, p5.id]),
+             limit: 3
+           }
+  end
+
+  test "sorts on two different directions with before and after cursor", %{
+    payments: {_p1, _p2, _p3, p4, p5, p6, p7, p8, _p9, _p10, _p11, _p12}
+  } do
+    %Page{entries: entries, metadata: metadata} =
+      payments_by_amount_and_charged_at(:desc, :asc)
+      |> Repo.paginate(
+        cursor_fields: [amount: :desc, charged_at: :asc, id: :asc],
+        after: encode_cursor([p8.amount, p8.charged_at, p8.id]),
+        before: encode_cursor([p6.amount, p6.charged_at, p6.id]),
+        limit: 8
+      )
+
+    assert to_ids(entries) == to_ids([p7, p5, p4])
+
+    assert metadata == %Metadata{
+             after: encode_cursor([p4.amount, p4.charged_at, p4.id]),
+             before: encode_cursor([p7.amount, p7.charged_at, p7.id]),
+             limit: 8
+           }
+  end
+
+  test "expect to raise on incorrect sorting value" do
+    assert_raise RuntimeError,
+                 "Value for field :amount in cursor_fields is invalid, please use either :desc or :asc",
+                 fn ->
+                   payments_by_amount_and_charged_at(:desc, :asc)
+                   |> Repo.paginate(
+                     cursor_fields: [amount: :test, charged_at: :asc, id: :asc],
+                     limit: 8
+                   )
+                 end
   end
 
   defp to_ids(entries), do: Enum.map(entries, & &1.id)
@@ -684,7 +757,10 @@ defmodule PaginatorTest do
     p11 = insert(:payment, customer: c3, charged_at: days_ago(2))
     p12 = insert(:payment, customer: c3, charged_at: days_ago(5))
 
-    {:ok, customers: {c1, c2, c3}, addresses: {a1, a2, a3}, payments: {p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12}}
+    {:ok,
+     customers: {c1, c2, c3},
+     addresses: {a1, a2, a3},
+     payments: {p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12}}
   end
 
   defp payments_by_status(status, direction \\ :asc) do
@@ -692,6 +768,18 @@ defmodule PaginatorTest do
       p in Payment,
       where: p.status == ^status,
       order_by: [{^direction, p.charged_at}, {^direction, p.id}],
+      select: p
+    )
+  end
+
+  defp payments_by_amount_and_charged_at(amount_direction, charged_at_direction) do
+    from(
+      p in Payment,
+      order_by: [
+        {^amount_direction, p.amount},
+        {^charged_at_direction, p.charged_at},
+        {:asc, p.id}
+      ],
       select: p
     )
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -21,7 +21,8 @@ defmodule Paginator.Factory do
     %Payment{
       description: "Skittles",
       charged_at: DateTime.utc_now(),
-      amount: :rand.uniform(100),
+      # +10 so it doesn't mess with low amounts we want to order on.
+      amount: :rand.uniform(100) + 10,
       status: "success",
       customer: build(:customer)
     }


### PR DESCRIPTION
Hey there, first of all: thanks for your great library! We have been using it for a while and it works like a charm. 

I built this feature because we have some queries that have fields sorting in both ascending order and descending order. 

### Example use
```elixir
      Notifications.get_all_query(user)
      |> order_by(asc: :is_read, desc: :created_at, desc: :id)
      |> Project.Repo.paginate(
        cursor_fields: [:is_read, :created_at, :id],
        sort_direction: [asc: :is_read, desc: :created_at, desc: :id]
      )
```

`sort_direction` can still be a single `:asc` or `:desc`

### Behaviour for queries
If an `after` cursor field is `:asc`, it will create a where statement in which it compares whether values are less than the cursor field.
If that cursor field is `:desc` it will compare whether values are greater than the cursor field.

The same applies for `before` cursors, but the other way around :)

I'm happy to make any changes, if you have any suggestions/ideas on how to improve this feature, and am also more than happy to write documentation for this feature as soon as it gets approved.

Also fixes the issue from #23