### PR TITLE
Remove explicit primary key selection from count

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -213,7 +213,6 @@ defmodule Paginator do
       |> exclude(:preload)
       |> exclude(:select)
       |> exclude(:order_by)
-      |> select([e], struct(e, [total_count_primary_key_field]))
       |> subquery
       |> select(count("*"))
       |> repo.one(repo_opts)
@@ -228,7 +227,6 @@ defmodule Paginator do
       |> exclude(:select)
       |> exclude(:order_by)
       |> limit(^(total_count_limit + 1))
-      |> select([e], struct(e, [total_count_primary_key_field]))
       |> subquery
       |> select(count("*"))
       |> repo.one(repo_opts)


### PR DESCRIPTION
The additional select causes unexpected failures when the given
queryable already has a subselect in it. E.g. it raises the following
error:

```
** (Ecto.SubQueryError) the following exception happened when compiling a subquery.

    ** (Ecto.QueryError) it is not possible to return a map/struct subset of a subquery, you must explicitly select the whole subquery or individual fields only in query:

    from v0 in subquery(from v0 in MyWebApp.EventFeedback,
      where: v0.user_id == ^"73ef72cd-4975-4baf-b755-4b7ee5ff1709",
      select: %MyWebApp.EventFeedback{id: v0.id, comment: v0.comment, rating: v0.rating, visit_id: v0.visit_id, user_id: v0.user_id, inserted_at: v0.inserted_at, updated_at: v0.updated_at}),
      join: a1 in MyWebApp.user,
      on: a1.id == v0.user_id,
      where: a1.id == ^"73ef72cd-4975-4baf-b755-4b7ee5ff1709",
      limit: ^10001,
      select: struct(v0, [:id])

The subquery originated from the following query:

from v0 in subquery(from v0 in subquery(from v0 in MyWebApp.EventFeedback,
  where: v0.user_id == ^"73ef72cd-4975-4baf-b755-4b7ee5ff1709"),
  join: a1 in assoc(v0, :user),
  where: a1.id == ^"73ef72cd-4975-4baf-b755-4b7ee5ff1709",
  limit: ^10001,
  select: struct(v0, [:id])),
  select: count("*")

    (ecto) lib/ecto/repo/queryable.ex:132: Ecto.Repo.Queryable.execute/4
    (ecto) lib/ecto/repo/queryable.ex:18: Ecto.Repo.Queryable.all/3
```

This may be less performant but it behaves as expected.