### PR TITLE
Improves default lookup of cursor values for one-level deep joins

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -236,14 +236,17 @@ defmodule Paginator do
 
       iex> Paginator.default_fetch_cursor_value(%Paginator.Customer{id: 1, address: %Paginator.Address{city: "London"}}, {:address, :city})
       "London"
+
+      iex> Paginator.default_fetch_cursor_value(%Paginator.Payment{id: 1, customer: %Paginator.Customer{id: 2}}, {:customer, :id})
+      2
   """
 
   @spec default_fetch_cursor_value(map(), atom() | {atom(), atom()}) :: any()
   def default_fetch_cursor_value(schema, {binding, field})
       when is_atom(binding) and is_atom(field) do
-    case Map.get(schema, field) do
-      nil -> Map.get(schema, binding) |> Map.get(field)
-      value -> value
+    case Map.get(schema, binding) do
+      nil -> Map.get(schema, field)
+      assoc -> Map.get(assoc, field)
     end
   end
 

--- a/test/paginator_test.exs
+++ b/test/paginator_test.exs
@@ -740,6 +740,9 @@ defmodule PaginatorTest do
              encode_cursor([p1.charged_at, p1.id])
 
     assert Paginator.cursor_for_record(p7, amount: :asc) == encode_cursor([p7.amount])
+
+    assert Paginator.cursor_for_record(p7, [{{:customer, :id}, :asc}]) ==
+             encode_cursor([p7.customer.id])
   end
 
   test "per-record cursor generation with custom cursor value function", %{


### PR DESCRIPTION
Hi,

This PR changes the way the cursor value is fetched in the default `default_fetch_cursor_value/2`.
Without this change the value would be fetched without first attempting to find a association that matches the binding.
I think this matches better with the docs at https://github.com/duffelhq/paginator/blob/master/lib/paginator.ex#L228 

kr, 
Stefan