### PR TITLE
Add support for cursor custom conversion

### DIFF
--- a/lib/paginator/cursor.ex
+++ b/lib/paginator/cursor.ex
@@ -1,16 +1,17 @@
 defmodule Paginator.Cursor do
   @moduledoc false
-
   def decode(nil), do: nil
 
   def decode(encoded_cursor) do
     encoded_cursor
     |> Base.url_decode64!()
     |> :erlang.binary_to_term([:safe])
+    |> Enum.map(&Paginator.Cursor.Decode.convert/1)
   end
 
   def encode(values) when is_list(values) do
     values
+    |> Enum.map(&Paginator.Cursor.Encode.convert/1)
     |> :erlang.term_to_binary()
     |> Base.url_encode64()
   end
@@ -18,4 +19,24 @@ defmodule Paginator.Cursor do
   def encode(value) do
     encode([value])
   end
+end
+
+defprotocol Paginator.Cursor.Encode do
+  @fallback_to_any true
+
+  def convert(term)
+end
+
+defprotocol Paginator.Cursor.Decode do
+  @fallback_to_any true
+
+  def convert(term)
+end
+
+defimpl Paginator.Cursor.Encode, for: Any do
+  def convert(term), do: term
+end
+
+defimpl Paginator.Cursor.Decode, for: Any do
+  def convert(term), do: term
 end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Paginator.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
+      consolidate_protocols: Mix.env() != :test,
       deps: deps(),
 
       # Hex

--- a/test/paginator/cursor_test.exs
+++ b/test/paginator/cursor_test.exs
@@ -1,9 +1,42 @@
 defmodule Paginator.CursorTest do
   use ExUnit.Case, async: true
 
+  defmodule MYTEST1 do
+    defstruct id: nil
+  end
+
+  defmodule MYTEST2 do
+    defstruct id: nil
+  end
+
+  defimpl Paginator.Cursor.Encode, for: MYTEST1 do
+    def convert(term), do: {:m1, term.id}
+  end
+
+  defimpl Paginator.Cursor.Decode, for: Tuple do
+    def convert({:m1, id}), do: %MYTEST1{id: id}
+  end
+
   alias Paginator.Cursor
 
   describe "encoding and decoding terms" do
+    test "cursor for struct with custom implementation is shorter" do
+      cursor1 = Cursor.encode([%MYTEST1{id: 1}])
+
+      assert Cursor.decode(cursor1) == [%MYTEST1{id: 1}]
+
+      cursor2 = Cursor.encode([%MYTEST2{id: 1}])
+
+      assert Cursor.decode(cursor2) == [%MYTEST2{id: 1}]
+      assert bit_size(cursor1) < bit_size(cursor2)
+    end
+
+    test "list of lists " do
+      cursor = Cursor.encode([[1]])
+
+      assert Cursor.decode(cursor) == [[1]]
+    end
+
     test "it wraps terms into lists" do
       cursor = Cursor.encode(1)
 


### PR DESCRIPTION
Related to this: https://github.com/duffelhq/paginator/issues/61
This PR solves my issue with minimal changes
I've added the following lines to my application:
```elixir
defimpl Paginator.Cursor.Encode, for: DateTime do
  def convert(term), do: {:dt, DateTime.to_unix(term, :microsecond)}
end

defimpl Paginator.Cursor.Decode, for: Tuple do
  def convert({:dt, unix_timestamp}), do: DateTime.from_unix!(unix_timestamp, :microsecond)
end
```
```elixir
> datetime = DateTime.utc_now
#DateTime<2019-04-03 11:25:47.435854Z>

# before:
> Paginator.Cursor.encode([datetime])
"g2wAAAABdAAAAA1kAApfX3N0cnVjdF9fZAAPRWxpeGlyLkRhdGVUaW1lZAAIY2FsZW5kYXJkABNFbGl4aXIuQ2FsZW5kYXIuSVNPZAADZGF5YQNkAARob3VyYQtkAAttaWNyb3NlY29uZGgCYgAGpo5hBmQABm1pbnV0ZWEZZAAFbW9udGhhBGQABnNlY29uZGEvZAAKc3RkX29mZnNldGEAZAAJdGltZV96b25lbQAAAAdFdGMvVVRDZAAKdXRjX29mZnNldGEAZAAEeWVhcmIAAAfjZAAJem9uZV9hYmJybQAAAANVVENq"

# after:
> Paginator.Cursor.encode([datetime])                                                        
"g2wAAAABaAJkAAJkdG4HAE7r4IOehQVq"
```

The idea with custom cursor module from https://github.com/duffelhq/paginator/pull/9 looks more flexible, but there is no moving for a long time there, it is a bit outdated and I found it only during preparing this PR.