### PR TITLE
Expand travis test matrix with elixir 1.7/1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: elixir
 sudo: false
 elixir:
-  - 1.4
-  - 1.5
-  - 1.6
+  - 1.4.5
+  - 1.5.3
+  - 1.6.6
+  - 1.7.4
+  - 1.8.1
 otp_release:
+  - 21.3
+  - 20.3
   - 19.3
-  - 20.0
+matrix:
+  exclude:
+    - otp_release: 21.3
+      elixir: 1.4.5
+    - otp_release: 21.3
+      elixir: 1.5.3
+    - otp_release: 19.3
+      elixir: 1.8.1
 services:
   - postgresql
 before_script:


### PR DESCRIPTION
Right now the library is not tested on OTP 21 and elixir 1.7, 1.8. It makes sense to add these to the test matrix as they are the most recent versions and in my experience very common versions to run.

