### PR TITLE
Fixes cursor mismatch bug

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -174,8 +174,7 @@ defmodule Paginator do
   def paginate(queryable, opts, repo, repo_opts) do
     config = Config.new(opts)
 
-    unless config.cursor_fields,
-      do: raise("expected `:cursor_fields` to be set in call to paginate/3")
+    Config.validate!(config)
 
     sorted_entries = entries(queryable, config, repo, repo_opts)
     paginated_entries = paginate_entries(sorted_entries, config)

--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -203,10 +203,10 @@ defmodule Paginator do
   ### Example
 
       iex> Paginator.cursor_for_record(%Paginator.Customer{id: 1}, [:id])
-      "g2sAAQE="
+      "g3QAAAABZAACaWRhAQ=="
 
       iex> Paginator.cursor_for_record(%Paginator.Customer{id: 1, name: "Alice"}, [id: :asc, name: :desc])
-      "g2wAAAACYQFtAAAABUFsaWNlag=="
+      "g3QAAAACZAACaWRhAWQABG5hbWVtAAAABUFsaWNl"
   """
   @spec cursor_for_record(any(), [atom], (map(), atom() | {atom(), atom()} -> any())) :: binary()
   def cursor_for_record(
@@ -306,9 +306,13 @@ defmodule Paginator do
        }) do
     cursor_fields
     |> Enum.map(fn
-      {cursor_field, _order} -> fetch_cursor_value_fun.(schema, cursor_field)
-      cursor_field when is_atom(cursor_field) -> fetch_cursor_value_fun.(schema, cursor_field)
+      {cursor_field, _order} ->
+        {cursor_field, fetch_cursor_value_fun.(schema, cursor_field)}
+
+      cursor_field when is_atom(cursor_field) ->
+        {cursor_field, fetch_cursor_value_fun.(schema, cursor_field)}
     end)
+    |> Map.new()
     |> Cursor.encode()
   end
 

--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -33,7 +33,7 @@ defmodule Paginator.Config do
       after_values: Cursor.decode(opts[:after]),
       before: opts[:before],
       before_values: Cursor.decode(opts[:before]),
-      cursor_fields: opts[:cursor_fields] || [],
+      cursor_fields: opts[:cursor_fields],
       fetch_cursor_value_fun:
         opts[:fetch_cursor_value_fun] || (&Paginator.default_fetch_cursor_value/2),
       include_total_count: opts[:include_total_count] || false,
@@ -44,6 +44,35 @@ defmodule Paginator.Config do
       total_count_limit: opts[:total_count_limit] || @default_total_count_limit
     }
     |> convert_deprecated_config()
+  end
+
+  def validate!(%__MODULE__{} = config) do
+    unless config.cursor_fields do
+      raise(ArgumentError, "expected `:cursor_fields` to be set")
+    end
+
+    if !cursor_values_match_cursor_fields?(config.after_values, config.cursor_fields) do
+      raise(ArgumentError, message: "expected `:after` cursor to match `:cursor_fields`")
+    end
+
+    if !cursor_values_match_cursor_fields?(config.before_values, config.cursor_fields) do
+      raise(ArgumentError, message: "expected `:before` cursor to match `:cursor_fields`")
+    end
+  end
+
+  defp cursor_values_match_cursor_fields?(nil = _cursor_values, _cursor_fields), do: true
+
+  defp cursor_values_match_cursor_fields?(cursor_values, _cursor_fields)
+       when is_list(cursor_values) do
+    # Legacy cursors are valid by default
+    true
+  end
+
+  defp cursor_values_match_cursor_fields?(cursor_values, cursor_fields) do
+    cursor_keys = cursor_values |> Map.keys() |> Enum.sort()
+    sorted_cursor_fields = cursor_fields |> Keyword.keys() |> Enum.sort()
+
+    match?(^cursor_keys, sorted_cursor_fields)
   end
 
   defp limit(opts) do
@@ -69,10 +98,12 @@ defmodule Paginator.Config do
     end
   end
 
+  defp build_cursor_fields_from_sort_direction(nil, sorting_direction), do: nil
+
   defp build_cursor_fields_from_sort_direction(fields, sorting_direction) do
     Enum.map(fields, fn
       {{_binding, _column}, _direction} = field -> field
-      {_column, direction} = field when direction in @order_directions  -> field
+      {_column, direction} = field when direction in @order_directions -> field
       {_binding, _column} = field -> {field, sorting_direction}
       field -> {field, sorting_direction}
     end)

--- a/lib/paginator/cursor.ex
+++ b/lib/paginator/cursor.ex
@@ -9,13 +9,9 @@ defmodule Paginator.Cursor do
     |> :erlang.binary_to_term([:safe])
   end
 
-  def encode(values) when is_list(values) do
+  def encode(values) when is_map(values) do
     values
     |> :erlang.term_to_binary()
     |> Base.url_encode64()
-  end
-
-  def encode(value) do
-    encode([value])
   end
 end

--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -36,12 +36,19 @@ defmodule Paginator.Ecto.Query do
     get_operator(order, direction)
   end
 
-  defp filter_values(query, fields, values, cursor_direction) do
-    sorts =
+  # This clause is responsible for transforming legacy list cursors into map cursors
+  defp filter_values(query, fields, values, cursor_direction) when is_list(values) do
+    new_values =
       fields
       |> Keyword.keys()
       |> Enum.zip(values)
-      |> Enum.reject(fn val -> match?({_column, nil}, val) end)
+      |> Map.new()
+
+    filter_values(query, fields, new_values, cursor_direction)
+  end
+
+  defp filter_values(query, fields, values, cursor_direction) when is_map(values) do
+    sorts = Enum.reject(values, fn val -> match?({_column, nil}, val) end)
 
     dynamic_sorts =
       sorts

--- a/test/paginator/config_test.exs
+++ b/test/paginator/config_test.exs
@@ -83,7 +83,7 @@ defmodule Paginator.ConfigTest do
       config = Config.new(limit: 10, cursor_fields: [:id], before: simple_before())
 
       assert config.after_values == nil
-      assert config.before_values == ["pay_789"]
+      assert config.before_values == %{id: "pay_789"}
       assert config.limit == 10
       assert config.cursor_fields == [id: :asc]
     end
@@ -91,7 +91,7 @@ defmodule Paginator.ConfigTest do
     test "simple after" do
       config = Config.new(limit: 10, cursor_fields: [:id], after: simple_after())
 
-      assert config.after_values == ["pay_123"]
+      assert config.after_values == %{id: "pay_123"}
       assert config.before_values == nil
       assert config.limit == 10
       assert config.cursor_fields == [id: :asc]
@@ -101,7 +101,7 @@ defmodule Paginator.ConfigTest do
       config = Config.new(limit: 10, cursor_fields: [:created_at, :id], before: complex_before())
 
       assert config.after_values == nil
-      assert config.before_values == ["2036-02-09T20:00:00.000Z", "pay_789"]
+      assert config.before_values == %{date: "2036-02-09T20:00:00.000Z", id: "pay_789"}
       assert config.limit == 10
       assert config.cursor_fields == [created_at: :asc, id: :asc]
     end
@@ -109,15 +109,15 @@ defmodule Paginator.ConfigTest do
     test "complex after" do
       config = Config.new(limit: 10, cursor_fields: [:created_at, :id], after: complex_after())
 
-      assert config.after_values == ["2036-02-09T20:00:00.000Z", "pay_123"]
+      assert config.after_values == %{date: "2036-02-09T20:00:00.000Z", id: "pay_123"}
       assert config.before_values == nil
       assert config.limit == 10
       assert config.cursor_fields == [created_at: :asc, id: :asc]
     end
   end
 
-  def simple_after, do: Cursor.encode("pay_123")
-  def simple_before, do: Cursor.encode("pay_789")
-  def complex_after, do: Cursor.encode(["2036-02-09T20:00:00.000Z", "pay_123"])
-  def complex_before, do: Cursor.encode(["2036-02-09T20:00:00.000Z", "pay_789"])
+  def simple_after, do: Cursor.encode(%{id: "pay_123"})
+  def simple_before, do: Cursor.encode(%{id: "pay_789"})
+  def complex_after, do: Cursor.encode(%{date: "2036-02-09T20:00:00.000Z", id: "pay_123"})
+  def complex_before, do: Cursor.encode(%{date: "2036-02-09T20:00:00.000Z", id: "pay_789"})
 end

--- a/test/paginator/config_test.exs
+++ b/test/paginator/config_test.exs
@@ -116,6 +116,32 @@ defmodule Paginator.ConfigTest do
     end
   end
 
+  describe "Config.validate!/1" do
+    test "raises ArgumentError when cursor_fields are not set" do
+      config = Config.new([])
+
+      assert_raise ArgumentError, "expected `:cursor_fields` to be set", fn ->
+        Config.validate!(config)
+      end
+    end
+
+    test "raises ArgumentError when after cursor does not match the cursor_fields" do
+      config = Config.new(cursor_fields: [:date], after: complex_after())
+
+      assert_raise ArgumentError, "expected `:after` cursor to match `:cursor_fields`", fn ->
+        Config.validate!(config)
+      end
+    end
+
+    test "raises ArgumentError when before cursor does not match the cursor_fields" do
+      config = Config.new(cursor_fields: [:id], before: complex_before())
+
+      assert_raise ArgumentError, "expected `:before` cursor to match `:cursor_fields`", fn ->
+        Config.validate!(config)
+      end
+    end
+  end
+
   def simple_after, do: Cursor.encode(%{id: "pay_123"})
   def simple_before, do: Cursor.encode(%{id: "pay_789"})
   def complex_after, do: Cursor.encode(%{date: "2036-02-09T20:00:00.000Z", id: "pay_123"})

--- a/test/paginator/cursor_test.exs
+++ b/test/paginator/cursor_test.exs
@@ -4,17 +4,10 @@ defmodule Paginator.CursorTest do
   alias Paginator.Cursor
 
   describe "encoding and decoding terms" do
-    test "it wraps terms into lists" do
-      cursor = Cursor.encode(1)
+    test "it encodes and decodes map cursors" do
+      cursor = Cursor.encode(%{a: 1, b: 2})
 
-      assert Cursor.decode(cursor) == [1]
-    end
-
-    test "it doesn't wrap a list in a list" do
-      cursor = Cursor.encode([1])
-
-      assert Cursor.decode(cursor) == [1]
-      refute Cursor.decode(cursor) == [[1]]
+      assert Cursor.decode(cursor) == %{a: 1, b: 2}
     end
   end
 


### PR DESCRIPTION
## Bug

```elixir
record = %{id: "123", date: "2020-08-01"}
cursor = Paginator.cursor_for_record(record, [:id, :date])
page = Paginator.paginate(cursor_fields: [:date], after: cursor)
```

The example above will produce an invalid query because the columns in
the cursor don't match the columns in the `cursor_fields`. In practice
Paginator will generate a query with a filter on the `date` column based
on the value of the id.

## Fix

The fix in this PR consists in changing the data structure of the cursor from a list to a map, so that we can store the column names along with the cursor values. With this change we can actually validate that the columns in the cursor match the columns in the `cursor_fields`.

This changes introduced are backward compatible.

See the individual commits for more details.

## Open questions

- The change from a list to a map will increase the size of the cursor. How much of a problem is this?
- If the cursor columns don't match the `cursor_fields` an `ArgumentError` is raised. Should we return an error tuple instead?