### PR TITLE
Update Elixir and Erlang/OTP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,18 @@ elixir:
   - 1.9
   - 1.10
 otp_release:
-  - 19.3
+  - 19.0
   - 20.0
   - 21.0
   - 22.0
 matrix:
   exclude:
   - elixir: 1.8
-    otp_version: 19.3
+    otp_version: 19.0
   - elixir: 1.9
-    otp_version: 19.3
+    otp_version: 19.0
   - elixir: 1.10
-    otp_version: 19.3
+    otp_version: 19.0
   - elixir: 1.10
     otp_version: 20.0
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: elixir
 sudo: false
 elixir:
-  - 1.4
-  - 1.5
-  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
+  - 1.10
 otp_release:
   - 19.3
   - 20.0
+  - 21.0
+  - 22.0
+matrix:
+  exclude:
+  - elixir: 1.8
+    otp_version: 19.3
+  - elixir: 1.9
+    otp_version: 19.3
+  - elixir: 1.10
+    otp_version: 19.3
+  - elixir: 1.10
+    otp_version: 20.0
 services:
   - postgresql
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,20 @@ elixir:
   - 1.9
   - 1.10
 otp_release:
-  - 19.0
+  - 19.3
   - 20.0
   - 21.0
   - 22.0
 matrix:
   exclude:
   - elixir: 1.8
-    otp_version: 19.0
+    otp_release: 19.3
   - elixir: 1.9
-    otp_version: 19.0
+    otp_release: 19.3
   - elixir: 1.10
-    otp_version: 19.0
+    otp_release: 19.3
   - elixir: 1.10
-    otp_version: 20.0
+    otp_release: 20.0
 services:
   - postgresql
 before_script:


### PR DESCRIPTION
💁 These changes update the continuous integration build matrix to:
* Remove old, end-of-life Elixir versions; and
* Add new Elixir and Erlang/OTP versions

See https://hexdocs.pm/elixir/compatibility-and-deprecations.html for further information on this compatibility matrix.