### PR TITLE
Fix compilation warning for unused variable

### DIFF
--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -98,7 +98,7 @@ defmodule Paginator.Config do
     end
   end
 
-  defp build_cursor_fields_from_sort_direction(nil, sorting_direction), do: nil
+  defp build_cursor_fields_from_sort_direction(nil, _sorting_direction), do: nil
 
   defp build_cursor_fields_from_sort_direction(fields, sorting_direction) do
     Enum.map(fields, fn

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Paginator.Mixfile do
       app: :paginator,
       version: @version,
       elixir: "~> 1.5",
+      elixirc_options: [warnings_as_errors: System.get_env("CI") == "true"],
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
💁 These changes resolve the following warning at compile time:

    warning: variable "sorting_direction" is unused (if the variable is not meant to be used, prefix it with an underscore)
      lib/paginator/config.ex:101: Paginator.Config.build_cursor_fields_from_sort_direction/2

💭 Perhaps we could prevent warnings like this being merged accidentally by adding a line like 
```elixir
elixirc_options: [warnings_as_errors: System.get_env("CI") == "true"]
```
to `mix.exs`?