### PR TITLE
Fixes bug that generates queries with cursor conditions out of order

### DIFF
--- a/lib/paginator/ecto/query.ex
+++ b/lib/paginator/ecto/query.ex
@@ -48,7 +48,10 @@ defmodule Paginator.Ecto.Query do
   end
 
   defp filter_values(query, fields, values, cursor_direction) when is_map(values) do
-    sorts = Enum.reject(values, fn val -> match?({_column, nil}, val) end)
+    sorts =
+      fields
+      |> Enum.map(fn {column, _order} -> {column, Map.get(values, column)} end)
+      |> Enum.reject(fn val -> match?({_column, nil}, val) end)
 
     dynamic_sorts =
       sorts


### PR DESCRIPTION
In https://github.com/duffelhq/paginator/pull/68 we changed the cursor
data structure from a list to a map. Because elements in a map don't
have order among them, this change introduced a bug that causes
paginator to generate pagination queries with the cursor conditions
following the order in which they are stored in a map (which is random).

This PR fixes this by enforcing the cursor_fields order on the
cursor values when generating the pagination queries.
