### PR TITLE
Support all order directions

### DIFF
--- a/lib/paginator/config.ex
+++ b/lib/paginator/config.ex
@@ -25,7 +25,14 @@ defmodule Paginator.Config do
   @minimum_limit 1
   @maximum_limit 500
   @default_total_count_limit 10_000
-  @order_directions [:asc, :desc]
+  @order_directions [
+    :asc,
+    :asc_nulls_last,
+    :asc_nulls_first,
+    :desc,
+    :desc_nulls_last,
+    :desc_nulls_first
+  ]
 
   def new(opts \\ []) do
     %__MODULE__{


### PR DESCRIPTION
As specified [here](https://hexdocs.pm/ecto/Ecto.Query.html#order_by/3), Ecto supports six order directions: `:asc`, `:asc_nulls_last`, `:asc_nulls_first`, `:desc`, `:desc_nulls_last`, and `:desc_nulls_first`.