### PR TITLE
CI: Add Elixir 1.11, OTP 23 to build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,32 @@ elixir:
   - 1.8
   - 1.9
   - 1.10
+  - 1.11
 otp_release:
   - 19.3
   - 20.0
   - 21.0
   - 22.0
+  - 23.0
 matrix:
   exclude:
   - elixir: 1.8
     otp_release: 19.3
+  - elixir: 1.8
+    otp_release: 23.0
   - elixir: 1.9
     otp_release: 19.3
+  - elixir: 1.9
+    otp_release: 23.0
   - elixir: 1.10
     otp_release: 19.3
   - elixir: 1.10
+    otp_release: 20.0
+  - elixir: 1.10
+    otp_release: 23.0
+  - elixir: 1.11
+    otp_release: 19.3
+  - elixir: 1.11
     otp_release: 20.0
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ otp_release:
   - 23.0
 matrix:
   exclude:
+  - elixir: 1.7
+    otp_release: 23.0
   - elixir: 1.8
     otp_release: 19.3
   - elixir: 1.8


### PR DESCRIPTION
💁 This change adds Elixir 1.11.0 and Erlang/OTP 23 to the Travis CI build configuration.