### PR TITLE
Prepare for 1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.2 - 2020-11-20
+
+* Update package dependencies
+  * `inch` -> 2.0
+  * `plug_crypto` -> 1.2.0
+  * `ex_doc` -> 0.23.0
+
 ## v1.0.1 - 2020-08-18
 
 * Fix sorting bug in cursor query ([#73](https://github.com/duffelhq/paginator/pull/73))

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add `paginator` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:paginator, "~> 1.0.1"}]
+  [{:paginator, "~> 1.0.2"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Paginator.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.2"
 
   def project do
     [


### PR DESCRIPTION
💁 These changes prepare this package for a release of version 1.0.2.

Closes #89 