### PR TITLE
tweak to appease dialyzer

### DIFF
--- a/lib/paginator/page/metadata.ex
+++ b/lib/paginator/page/metadata.ex
@@ -18,8 +18,8 @@ defmodule Paginator.Page.Metadata do
           after: opaque_cursor() | nil,
           before: opaque_cursor() | nil,
           limit: integer(),
-          total_count: integer(),
-          total_count_cap_exceeded: boolean()
+          total_count: integer() | nil,
+          total_count_cap_exceeded: boolean() | nil
         }
 
   defstruct [:after, :before, :limit, :total_count, :total_count_cap_exceeded]


### PR DESCRIPTION
I found a couple more :)

It looks like `:limit` comes right from the config where it will definitely be an integer, but the other fields can end up nil, by the looks of it.

Thanks again!