### PR TITLE
CI: Run Inch task in separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,63 @@ on:
       - main
 
 jobs:
+  inch:
+    name: Analyse Documentation
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        elixir:
+        - "1.11"
+        otp:
+        - "23.0"
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }}
+        otp-version: ${{ matrix.otp }}
+
+    - name: Restore deps cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-mix-${{ matrix.otp }}
+          ${{ runner.os }}-mix
+
+    - name: Restore _build cache
+      uses: actions/cache@v2
+      with:
+        path: _build
+        key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-build-${{ matrix.otp }}
+          ${{ runner.os }}-build
+
+    - name: Install hex
+      run: mix local.hex --force
+
+    - name: Install rebar
+      run: mix local.rebar --force
+
+    - name: Install package dependencies
+      run: mix deps.get
+
+    - name: Check documentation quality
+      run: mix inch.report
+
   test:
-    name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    name: Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -89,6 +144,3 @@ jobs:
 
     - name: Run unit tests
       run: mix test
-
-    - name: Check documentation quality
-      run: mix inch.report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on:
   push:
-  pull_request:
-    branches:
-      - main
 
 jobs:
   inch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,10 @@ jobs:
     - name: Install package dependencies
       run: mix deps.get
 
-    - name: Check documentation quality
+    - name: Check documentation quality locally
+      run: mix inch
+
+    - name: Report documentation quality
       run: mix inch.report
 
   test:


### PR DESCRIPTION
💁 There's no need to run the documentation analysis in every Elixir and Erlang combination—just once is fine.

The other change of note relates to [Inch CI's remote host](https://inch-ci.org) being [down since 2021-02-25 with no resolution date set as yet](https://twitter.com/rrrene/status/1364882921979527169). I added another step to see the result of the report in standard output as well as reporting it upstream.