### PR TITLE
CI: Remove potentially invalid cache key matches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}
-          ${{ runner.os }}-mix
 
     - name: Restore _build cache
       uses: actions/cache@v2
@@ -76,8 +74,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
           ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-build-${{ matrix.otp }}
-          ${{ runner.os }}-build
 
     - name: Install hex
       run: mix local.hex --force


### PR DESCRIPTION
💁 These changes update the GitHub Actions CI build configuration previously added in #100. Having cache keys which map to a different Elixir version means that compiled files for an incompatible Elixir version can be restored, leading to errors like the following for Elixir 1.9 and OTP 20.0:

    Cache restored from key: Linux-build-21.0-1.11-ba70a7771907bbe8b53c5a436ab6a2c3a255d9ca68d021466bed7818259688df

Both the Elixir and OTP versions in the cached `_build/` directory didn't match that of the job, which lead to the following error:

    could not compile dependency :earmark_parser, "mix compile" failed. You can recompile this dependency with "mix deps.compile earmark_parser", update it with "mix deps.update earmark_parser" or clean it with "mix deps.clean earmark_parser"

Removing these potentially invalid cache keys and leaving those which match the Elixir and Erlang versions should prevent this from reoccurring.

See the build job for more information: https://github.com/duffelhq/paginator/pull/85/checks?check_run_id=2005881481