### PR TITLE
CI: Remove duplicated workflow run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on:
   push:
-  pull_request:
-    branches:
-      - main
 
 jobs:
   test:


### PR DESCRIPTION
💁 The test suite currently runs twice for pull requests. It should run on every push but running it again for a pull request against the main branch adds unnecessary duplication. I should have picked that up when reviewing #100.