### PR TITLE
Do not run tests with OTP 22.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,14 @@ name: Test
 
 on:
   push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   inch:
     name: Analyse Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -14,93 +17,6 @@ jobs:
         - "1.11"
         otp:
         - "23.0"
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Set up Elixir
-      uses: actions/setup-elixir@v1
-      with:
-        elixir-version: ${{ matrix.elixir }}
-        otp-version: ${{ matrix.otp }}
-
-    - name: Restore deps cache
-      uses: actions/cache@v2
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-mix-${{ matrix.otp }}
-          ${{ runner.os }}-mix
-
-    - name: Restore _build cache
-      uses: actions/cache@v2
-      with:
-        path: _build
-        key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
-          ${{ runner.os }}-build-${{ matrix.otp }}
-          ${{ runner.os }}-build
-
-    - name: Install hex
-      run: mix local.hex --force
-
-    - name: Install rebar
-      run: mix local.rebar --force
-
-    - name: Install package dependencies
-      run: mix deps.get
-
-    - name: Check documentation quality locally
-      run: mix inch
-
-    - name: Report documentation quality
-      run: mix inch.report
-
-  test:
-    name: Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        ports:
-        - 5432:5432
-        env:
-          POSTGRES_DB: paginator_test
-          POSTGRES_PASSWORD: postgres
-
-    strategy:
-      matrix:
-        elixir:
-        - "1.7"
-        - "1.8"
-        - "1.9"
-        - "1.10"
-        - "1.11"
-        otp:
-        - "19.3"
-        - "20.0"
-        - "21.0"
-        - "22.0"
-        - "23.0"
-        exclude:
-        - elixir: 1.8
-          otp: 19.3
-        - elixir: 1.9
-          otp: 19.3
-        - elixir: 1.10
-          otp: 19.3
-        - elixir: 1.10
-          otp: 20.0
-        - elixir: 1.11
-          otp: 19.3
-        - elixir: 1.11
-          otp: 20.0
 
     steps:
     - name: Checkout
@@ -141,6 +57,99 @@ jobs:
 
     - name: Remove compiled application files
       run: mix clean
+
+    - name: Compile dependencies
+      run: mix compile
+
+    - name: Check documentation quality locally
+      run: mix inch
+
+    - name: Report documentation quality
+      if: github.event_name == 'push'
+      run: mix inch.report
+
+  test:
+    name: Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres
+        ports:
+        - 5432:5432
+        env:
+          POSTGRES_DB: paginator_test
+          POSTGRES_PASSWORD: postgres
+
+    strategy:
+      matrix:
+        elixir:
+        - "1.7"
+        - "1.8"
+        - "1.9"
+        - "1.10"
+        - "1.11"
+        otp:
+        - "19.3"
+        - "20.0"
+        - "21.0"
+        - "22.0.2"
+        - "23.0"
+        exclude:
+        - elixir: "1.8"
+          otp: "19.3"
+        - elixir: "1.9"
+          otp: "19.3"
+        - elixir: "1.10"
+          otp: "19.3"
+        - elixir: "1.10"
+          otp: "20.0"
+        - elixir: "1.11"
+          otp: "19.3"
+        - elixir: "1.11"
+          otp: "20.0"
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }}
+        otp-version: ${{ matrix.otp }}
+
+    - name: Restore deps cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
+
+    - name: Restore _build cache
+      uses: actions/cache@v2
+      with:
+        path: _build
+        key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
+
+    - name: Install hex
+      run: mix local.hex --force
+
+    - name: Install rebar
+      run: mix local.rebar --force
+
+    - name: Install package dependencies
+      run: mix deps.get
+
+    - name: Remove compiled application files
+      run: mix clean
+
+    - name: Compile dependencies
+      run: mix compile
 
     - name: Run unit tests
       run: mix test


### PR DESCRIPTION
It looks like some of PRs are failing:
https://github.com/duffelhq/paginator/pull/107
https://github.com/duffelhq/paginator/pull/97

This is caused bu a bug in the 22.0.1 OTP version:
https://github.com/elixir-ecto/ecto/issues/3335#issuecomment-644201355 for more details

Here I've changed the matrix build to avoid this.

Also recently ubuntu-latest tag was changed, now it is pointing to ubuntu-20.04 instead of ubuntu-18.04. This causes an error during Elixir installation step:
https://github.com/dolfinus/paginator/runs/2045756587?check_suite_focus=true
So I've changed ubuntu version back to 18.04.

Another thing that was changed here - workflow has been updated to be run on pull_requests too.
Without this change every PR from an external repo will look like this:
![image](https://user-images.githubusercontent.com/4661021/110203237-15b38e00-7e7e-11eb-95f1-76b317a5d56a.png)
without actually running any of these checks.

Here is an example of workflow run:
https://github.com/dolfinus/paginator/actions/runs/633779496

And this is en example of run which will be performed after https://github.com/duffelhq/paginator/pull/97 rebase:
https://github.com/dolfinus/paginator/actions/runs/633782580