### PR TITLE
Automatically merge Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "mix"
+      - "dependencies"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,7 @@
 name: Automerge
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - assigned
       - opened
@@ -10,7 +10,7 @@ on:
       - synchronize
       - edited
       - ready_for_review
-      - review_requested
+      - review_requested 
       - reopened
       - unlocked
   pull_request_review:
@@ -22,8 +22,8 @@ jobs:
   automerge:
     name: Automatically merge pull requests
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
+      
     steps:
       - name: Wait for tests
         uses: fountainhead/action-wait-for-check@v1.0.0
@@ -34,16 +34,22 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
           intervalSeconds: 60
           timeoutSeconds: 3600
+          
+      - name: Approve PR
+        uses: hmarr/auto-approve-action@v2
+        if: steps.wait-for-tests.outputs.conclusion == 'success'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Merge PR
         if: steps.wait-for-tests.outputs.conclusion == 'success'
         uses: "pascalgn/automerge-action@v0.13.0"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: 'dependencies,!wip,!work in progress'
+          MERGE_LABELS: '!wip,!work in progress'
           MERGE_METHOD: rebase
           MERGE_FORKS: false
           MERGE_RETRIES: "5"
-          MERGE_RETRY_SLEEP: 10000
+          MERGE_RETRY_SLEEP: "10000"
           UPDATE_LABELS: ""
-          UPDATE_METHOD: rebase
+          UPDATE_METHOD: "rebase"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -39,13 +39,13 @@ jobs:
         uses: hmarr/auto-approve-action@v2
         if: steps.wait-for-tests.outputs.conclusion == 'success'
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.PERSONAL_TOKEN }}"
 
       - name: Merge PR
         if: steps.wait-for-tests.outputs.conclusion == 'success'
         uses: "pascalgn/automerge-action@v0.13.0"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PERSONAL_TOKEN }}"
           MERGE_LABELS: '!wip,!work in progress'
           MERGE_METHOD: rebase
           MERGE_FORKS: false

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,49 @@
+name: Automerge
+
+on:
+  pull_request:
+    types:
+      - assigned
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+      - edited
+      - ready_for_review
+      - review_requested
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - edited
+      - submitted
+
+jobs:
+  automerge:
+    name: Automatically merge pull requests
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Wait for tests
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Check result
+          ref: ${{ github.head_ref || github.ref }}
+          intervalSeconds: 60
+          timeoutSeconds: 3600
+
+      - name: Merge PR
+        if: steps.wait-for-tests.outputs.conclusion == 'success'
+        uses: "pascalgn/automerge-action@v0.13.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: 'dependencies,!wip,!work in progress'
+          MERGE_METHOD: rebase
+          MERGE_FORKS: false
+          MERGE_RETRIES: "5"
+          MERGE_RETRY_SLEEP: 10000
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: rebase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,3 +153,12 @@ jobs:
 
     - name: Run unit tests
       run: mix test
+
+  check_result:
+    name: Check result
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2


### PR DESCRIPTION
Hello.

I see that Dependabot integration is set up on your repo. Here I propose to add an automatic step of merging pull requests from this bot if tests have been passed successfully.

The only thing should be done for enabling this feature is generating new personal token with write repo write access and saving it as PERSONAL_TOKEN secret.

This is because events made using Github Actions token, like rebasing the branch and pushing commits, do not trigger workflow runs.
This leads to strange issues - for example, you've set branch protection rule and checked some workflow as mandatory (e.g. running tests), and then 2 Dependabot merge requests were created. First MR was approved and merged automatically, then the second MR was rebased by this action, but now workflow haven't been started this MR cannot be merged automatically.
Using personal access token instead of GITHUB_TOKEN solves this issue.