### PR TITLE
Fix example showing of joined fields passed into `fetch_cursor_value_fun`

### DIFF
--- a/lib/paginator.ex
+++ b/lib/paginator.ex
@@ -157,7 +157,7 @@ defmodule Paginator do
       Repo.paginate(query,
         cursor_fields: [{{:company, :name}, :asc}, id: :asc],
         fetch_cursor_value_fun: fn
-          post, {{:company, name}, _} ->
+          post, {:company, name} ->
             post.author.company.name
 
           post, field ->


### PR DESCRIPTION
The `fetch_cursor_value` function only passes `cursor_field` to the `fetch_cursor_value_fun`:

```
  defp fetch_cursor_value(schema, %Config{
         cursor_fields: cursor_fields,
         fetch_cursor_value_fun: fetch_cursor_value_fun
       }) do
    cursor_fields
    |> Enum.map(fn
      {cursor_field, _order} ->
        {cursor_field, fetch_cursor_value_fun.(schema, cursor_field)}

      cursor_field when is_atom(cursor_field) ->
        {cursor_field, fetch_cursor_value_fun.(schema, cursor_field)}
    end)
    |> Map.new()
    |> Cursor.encode()
  end
```

The documentation example is incorrect because it shows the entire `{cursor_field, direction}` tuple is passed as the second parameter.