### PR TITLE
Docs: close errant code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ end
     ```
 ## Security Considerations
 
-`Repo.paginate/4 will throw an ArgumentError should it detect an executable term in the cursor parameters passed to it (`before`, `after`).
+`Repo.paginate/4` will throw an `ArgumentError` should it detect an executable term in the cursor parameters passed to it (`before`, `after`).
 This is done to protect you from potential side-effects of malicious user input, see [paginator_test.exs](https://github.com/duffelhq/paginator/blob/master/test/paginator_test.exs#L820).
 
 ## Indexes


### PR DESCRIPTION
💁 This wasn't closed when originally added in ce4f0dbd0543f45dab9a596df839b01a026e6632.