### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.0 - 2022-02-08
+
+* Skip duplicated GitHub Actions runs: ([#110](https://github.com/duffelhq/paginator/pull/110), thanks! @dolfinus)
+* Fix typespec for `cursor_for_record()`: ([#114](https://github.com/duffelhq/paginator/pull/114), thanks!  @kaylenmistry)
+* Project badges and GitHub Actions updates, thanks! @sgerrand:
+  * ([#116](https://github.com/duffelhq/paginator/pull/116))
+  * ([#121](https://github.com/duffelhq/paginator/pull/121))
+  * ([#128](https://github.com/duffelhq/paginator/pull/128))
+  * ([#144](https://github.com/duffelhq/paginator/pull/128))
+* Updates to project documentation: ([#122](https://github.com/duffelhq/paginator/pull/122), thanks! @ikianmeng)
+* Fix example for joined fields: ([#123](https://github.com/duffelhq/paginator/pull/123), thanks! @nickdichev)
+* Add support for sorting order combinations: ([#136](https://github.com/duffelhq/paginator/pull/136), thanks! @dgvncz0f)
+* Update package dependencies
+  * `ex_doc` -> 0.28.0
+  * `ecto` -> 3.6.2
+  * `ecto_sql` -> 3.6.2
+  * `plug_crypto` -> 1.2.2
+  * `postgrex` -> 0.15.13
+
 ## v1.0.4 - 2021-03-15
 
 * Fix type errors, thanks! @djthread:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Add `:paginator` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:paginator, "~> 1.0.4"}
+    {:paginator, "~> 1.1.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Paginator.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/duffelhq/paginator"
-  @version "1.0.4"
+  @version "1.1.0"
 
   def project do
     [


### PR DESCRIPTION
💁 These changes prepare the release of version 1.1.0. 

See the changes to `CHANGELOG.md` for a summary of the changes which have been merged since version 1.0.4 or the following diff: https://github.com/duffelhq/paginator/compare/v1.0.4...9e5b1d21b71797966ec2be5e6eea8d628bb24dd2