### PR TITLE
Switch from Mix.Config to Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :paginator, ecto_repos: [Paginator.Repo]
 


### PR DESCRIPTION
[Mix.Config](https://hexdocs.pm/mix/1.13.4/Mix.Config.html) is deprecated and it is recommended to use [Config](https://hexdocs.pm/elixir/1.13.4/Config.html) now.