### PR TITLE
Dependabot: update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "09:00"
+  open-pull-requests-limit: 10
+
 - package-ecosystem: mix
   directory: "/"
   schedule:


### PR DESCRIPTION
💁 I noticed that a few of the GitHub Actions configured in the existing workflows for this project were outdated. This change configures Dependabot to keep them up-to-date.